### PR TITLE
register modal button disabled until password is filled out

### DIFF
--- a/src/app/components/register-modal/register-modal.component.html
+++ b/src/app/components/register-modal/register-modal.component.html
@@ -44,7 +44,7 @@
             <div class="modal-footer">
                 <div class="container text-center">
 
-                    <button type="button" class="btn btn-primary btn-block fa-lg gradient-custom-2"
+                    <button [disabled]="user.password.length < 8" type="button" class="btn btn-primary btn-block fa-lg gradient-custom-2"
                         (click)="registerUser()">Register</button>
                     <!-- IF there is a message, show it -->
                     


### PR DESCRIPTION
done in a hacky way: assuming that people fill out the form in order, the button to register will be enabled once the password is at least 8 chars long 